### PR TITLE
kafka/data/rpc: add consume RPC for partition reading

### DIFF
--- a/src/v/kafka/data/rpc/BUILD
+++ b/src/v/kafka/data/rpc/BUILD
@@ -31,6 +31,7 @@ redpanda_cc_library(
         "//src/v/config",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
+        "//src/v/kafka/data:log_reader_config",
         "//src/v/kafka/data:partition_proxy",
         "//src/v/model",
         "//src/v/raft",

--- a/src/v/kafka/data/rpc/client.cc
+++ b/src/v/kafka/data/rpc/client.cc
@@ -430,4 +430,64 @@ client::get_remote_partition_offsets(
     }
     co_return ret_t(std::move(result.value().partition_offsets));
 }
+
+ss::future<result<consume_reply, cluster::errc>> client::consume(
+  model::topic_partition tp,
+  kafka::offset start_offset,
+  kafka::offset max_offset,
+  size_t min_bytes,
+  size_t max_bytes,
+  model::timeout_clock::duration timeout) {
+    using ret_t = result<consume_reply, cluster::errc>;
+
+    // Find the leader for this partition
+    auto ktp = model::ktp(tp.topic, tp.partition);
+    auto leader = _leaders->get_leader_node(
+      model::topic_namespace_view(model::kafka_namespace, tp.topic),
+      tp.partition);
+
+    if (!leader) {
+        consume_reply reply;
+        reply.tp = tp;
+        reply.err = cluster::errc::not_leader;
+        co_return ret_t(std::move(reply));
+    }
+
+    consume_request req(
+      tp, start_offset, max_offset, min_bytes, max_bytes, timeout);
+
+    // If leader is local, call local service
+    if (*leader == _self) {
+        auto reply = co_await _local_service->local().consume(std::move(req));
+        co_return ret_t(std::move(reply));
+    }
+
+    // Otherwise call remote service
+    auto result
+      = co_await _connections->local()
+          .with_node_client<
+            kafka::data::rpc::impl::kafka_data_rpc_client_protocol>(
+            _self,
+            ss::this_shard_id(),
+            *leader,
+            timeout,
+            [req = std::move(req), timeout](
+              impl::kafka_data_rpc_client_protocol proto) mutable {
+                return proto.consume(
+                  std::move(req),
+                  ::rpc::client_opts(model::timeout_clock::now() + timeout));
+            })
+          .then([](auto ctx) {
+              return ::rpc::get_ctx_data<consume_reply>(std::move(ctx));
+          });
+
+    if (result.has_error()) {
+        consume_reply reply;
+        reply.tp = tp;
+        reply.err = map_errc(result.assume_error());
+        co_return ret_t(std::move(reply));
+    }
+
+    co_return ret_t(std::move(result.value()));
+}
 } // namespace kafka::data::rpc

--- a/src/v/kafka/data/rpc/client.h
+++ b/src/v/kafka/data/rpc/client.h
@@ -79,6 +79,14 @@ public:
     ss::future<result<partition_offsets_map, cluster::errc>>
       get_partition_offsets(chunked_vector<topic_partitions>);
 
+    ss::future<result<consume_reply, cluster::errc>> consume(
+      model::topic_partition,
+      kafka::offset start_offset,
+      kafka::offset max_offset,
+      size_t min_bytes,
+      size_t max_bytes,
+      model::timeout_clock::duration timeout);
+
 private:
     ss::future<cluster::errc> do_produce_once(produce_request);
     ss::future<produce_reply> do_local_produce(produce_request);

--- a/src/v/kafka/data/rpc/deps.cc
+++ b/src/v/kafka/data/rpc/deps.cc
@@ -123,6 +123,18 @@ public:
           shard_id, ktp, std::move(fn), require_leader);
     }
 
+    ss::future<result<ss::chunked_fifo<model::record_batch>, cluster::errc>>
+    consume_from_shard(
+      ss::shard_id shard_id,
+      const model::ktp& ktp,
+      ss::noncopyable_function<ss::future<
+        result<ss::chunked_fifo<model::record_batch>, cluster::errc>>(
+        kafka::partition_proxy*)> fn,
+      require_leader require_leader) final {
+        return _proxy->invoke_on_shard_impl(
+          shard_id, ktp, std::move(fn), require_leader);
+    }
+
 private:
     std::unique_ptr<partition_manager_proxy> _proxy;
 };

--- a/src/v/kafka/data/rpc/deps.h
+++ b/src/v/kafka/data/rpc/deps.h
@@ -192,6 +192,17 @@ public:
         result<partition_offsets, cluster::errc>>(kafka::partition_proxy*)>,
       require_leader req_leader = require_leader::yes)
       = 0;
+
+    virtual ss::future<
+      result<ss::chunked_fifo<model::record_batch>, cluster::errc>>
+    consume_from_shard(
+      ss::shard_id shard_id,
+      const model::ktp& ktp,
+      ss::noncopyable_function<ss::future<
+        result<ss::chunked_fifo<model::record_batch>, cluster::errc>>(
+        kafka::partition_proxy*)>,
+      require_leader req_leader = require_leader::yes)
+      = 0;
 };
 
 class partition_manager_proxy {

--- a/src/v/kafka/data/rpc/rpc.json
+++ b/src/v/kafka/data/rpc/rpc.json
@@ -14,6 +14,11 @@
             "name": "get_offsets",
             "input_type": "get_offsets_request",
             "output_type": "get_offsets_reply"
+        },
+        {
+            "name": "consume",
+            "input_type": "consume_request",
+            "output_type": "consume_reply"
         }
     ]
 }

--- a/src/v/kafka/data/rpc/serde.cc
+++ b/src/v/kafka/data/rpc/serde.cc
@@ -111,4 +111,22 @@ fmt::iterator get_offsets_reply::format_to(fmt::iterator it) const {
     return fmt::format_to(it, "] }}");
 }
 
+fmt::iterator consume_request::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{ tp: {}, start_offset: {}, max_offset: {}, min_bytes: {}, "
+      "max_bytes: {}, timeout: {} }}",
+      tp,
+      start_offset,
+      max_offset,
+      min_bytes,
+      max_bytes,
+      timeout);
+}
+
+fmt::iterator consume_reply::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{ tp: {}, err: {}, batches_size: {} }}", tp, err, batches.size());
+}
+
 } // namespace kafka::data::rpc

--- a/src/v/kafka/data/rpc/serde.cc
+++ b/src/v/kafka/data/rpc/serde.cc
@@ -43,100 +43,72 @@ produce_request produce_request::share() {
     return {std::move(shared), timeout};
 }
 
-} // namespace kafka::data::rpc
-
-auto fmt::formatter<kafka::data::rpc::produce_request>::format(
-  const kafka::data::rpc::produce_request& req, format_context& ctx) const
-  -> format_context::iterator {
+fmt::iterator kafka_topic_data::format_to(fmt::iterator it) const {
     return fmt::format_to(
-      ctx.out(),
+      it, "{{ tp: {}, batches_size: {} }}", tp, batches.size());
+}
+
+fmt::iterator produce_request::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
       "{{ topic_data: {}, timeout: {} }}",
-      fmt::join(req.topic_data, ", "),
-      req.timeout);
+      fmt::join(topic_data, ", "),
+      timeout);
 }
 
-auto fmt::formatter<kafka::data::rpc::kafka_topic_data>::format(
-  const kafka::data::rpc::kafka_topic_data& data, format_context& ctx) const
-  -> format_context::iterator {
-    return fmt::format_to(
-      ctx.out(),
-      "{{ tp: {}, batches_size: {} }}",
-      data.tp,
-      data.batches.size());
+fmt::iterator kafka_topic_data_result::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "{{ tp: {}, err: {} }}", tp, err);
 }
 
-auto fmt::formatter<kafka::data::rpc::produce_reply>::format(
-  const kafka::data::rpc::produce_reply& reply, format_context& ctx) const
-  -> format_context::iterator {
-    return fmt::format_to(
-      ctx.out(), "{{ results: {} }}", fmt::join(reply.results, ", "));
+fmt::iterator produce_reply::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "{{ results: {} }}", fmt::join(results, ", "));
 }
 
-auto fmt::formatter<kafka::data::rpc::kafka_topic_data_result>::format(
-  const kafka::data::rpc::kafka_topic_data_result& result,
-  format_context& ctx) const -> format_context::iterator {
+fmt::iterator topic_partitions::format_to(fmt::iterator it) const {
     return fmt::format_to(
-      ctx.out(), "{{ errc: {}, tp: {} }}", result.err, result.tp);
-}
-
-auto fmt::formatter<kafka::data::rpc::topic_partitions>::format(
-  const kafka::data::rpc::topic_partitions& tp, format_context& ctx) const
-  -> format_context::iterator {
-    return fmt::format_to(
-      ctx.out(),
+      it,
       "{{ topic: {}, partitions: {} }}",
-      tp.topic,
-      fmt::join(tp.partitions, ", "));
+      topic,
+      fmt::join(partitions, ", "));
 }
 
-auto fmt::formatter<kafka::data::rpc::get_offsets_request>::format(
-  const kafka::data::rpc::get_offsets_request& req, format_context& ctx) const
-  -> format_context::iterator {
+fmt::iterator partition_offsets::format_to(fmt::iterator it) const {
     return fmt::format_to(
-      ctx.out(), "{{ topics: {} }}", fmt::join(req.topics, ", "));
-}
-
-auto fmt::formatter<kafka::data::rpc::partition_offsets>::format(
-  const kafka::data::rpc::partition_offsets& po, format_context& ctx) const
-  -> format_context::iterator {
-    return fmt::format_to(
-      ctx.out(),
+      it,
       "{{ high_watermark: {}, last_stable_offset: {} }}",
-      po.high_watermark,
-      po.last_stable_offset);
+      high_watermark,
+      last_stable_offset);
 }
 
-auto fmt::formatter<kafka::data::rpc::partition_offset_result>::format(
-  const kafka::data::rpc::partition_offset_result& result,
-  format_context& ctx) const -> format_context::iterator {
-    return fmt::format_to(
-      ctx.out(), "{{ err: {}, offsets: {} }}", result.err, result.offsets);
+fmt::iterator partition_offset_result::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "{{ err: {}, offsets: {} }}", err, offsets);
 }
 
-auto fmt::formatter<kafka::data::rpc::get_offsets_reply>::format(
-  const kafka::data::rpc::get_offsets_reply& reply, format_context& ctx) const
-  -> format_context::iterator {
-    fmt::format_to(ctx.out(), "{{ partition_offsets: [");
+fmt::iterator get_offsets_request::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "{{ topics: {} }}", fmt::join(topics, ", "));
+}
+
+fmt::iterator get_offsets_reply::format_to(fmt::iterator it) const {
+    fmt::format_to(it, "{{ partition_offsets: [");
     bool first_topic = true;
-    for (const auto& [topic, partitions] : reply.partition_offsets) {
+    for (const auto& [topic, partitions] : partition_offsets) {
         if (!first_topic) {
-            fmt::format_to(ctx.out(), ", ");
+            fmt::format_to(it, ", ");
         }
         first_topic = false;
-        fmt::format_to(ctx.out(), "{{ topic: {}, partitions: [", topic);
+        fmt::format_to(it, "{{ topic: {}, partitions: [", topic);
         bool first_partition = true;
         for (const auto& [partition_id, result] : partitions) {
             if (!first_partition) {
-                fmt::format_to(ctx.out(), ", ");
+                fmt::format_to(it, ", ");
             }
             first_partition = false;
             fmt::format_to(
-              ctx.out(),
-              "{{ partition: {}, result: {} }}",
-              partition_id,
-              result);
+              it, "{{ partition: {}, result: {} }}", partition_id, result);
         }
-        fmt::format_to(ctx.out(), "] }}");
+        fmt::format_to(it, "] }}");
     }
-    return fmt::format_to(ctx.out(), "] }}");
+    return fmt::format_to(it, "] }}");
 }
+
+} // namespace kafka::data::rpc

--- a/src/v/kafka/data/rpc/serde.h
+++ b/src/v/kafka/data/rpc/serde.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "base/format_to.h"
 #include "cluster/errc.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
@@ -38,6 +39,8 @@ struct kafka_topic_data
     kafka_topic_data share();
 
     auto serde_fields() { return std::tie(tp, batches); }
+
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 
 struct produce_request
@@ -56,6 +59,8 @@ struct produce_request
 
     ss::chunked_fifo<kafka_topic_data> topic_data;
     model::timeout_clock::duration timeout{};
+
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 
 struct kafka_topic_data_result
@@ -72,6 +77,8 @@ struct kafka_topic_data_result
     cluster::errc err{cluster::errc::success};
 
     auto serde_fields() { return std::tie(tp, err); }
+
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 
 struct produce_reply
@@ -84,6 +91,8 @@ struct produce_reply
     auto serde_fields() { return std::tie(results); }
 
     ss::chunked_fifo<kafka_topic_data_result> results;
+
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 struct topic_partitions
   : serde::
@@ -97,6 +106,8 @@ struct topic_partitions
 
     model::topic topic;
     chunked_vector<model::partition_id> partitions;
+
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 
 struct partition_offsets
@@ -106,6 +117,8 @@ struct partition_offsets
 
     kafka::offset high_watermark;
     kafka::offset last_stable_offset;
+
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 struct partition_offset_result
   : serde::envelope<
@@ -124,6 +137,8 @@ struct partition_offset_result
 
     cluster::errc err{cluster::errc::success};
     partition_offsets offsets;
+
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 using partition_offsets_map = chunked_hash_map<
   model::topic,
@@ -142,6 +157,8 @@ struct get_offsets_request
     auto serde_fields() { return std::tie(topics); }
 
     chunked_vector<topic_partitions> topics;
+
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 struct get_offsets_reply
   : serde::
@@ -154,74 +171,7 @@ struct get_offsets_reply
     auto serde_fields() { return std::tie(partition_offsets); }
 
     partition_offsets_map partition_offsets;
+
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 } // namespace kafka::data::rpc
-
-template<>
-struct fmt::formatter<kafka::data::rpc::produce_request>
-  : formatter<std::string_view> {
-    auto
-    format(const kafka::data::rpc::produce_request&, format_context& ctx) const
-      -> format_context::iterator;
-};
-
-template<>
-struct fmt::formatter<kafka::data::rpc::kafka_topic_data>
-  : formatter<std::string_view> {
-    auto
-    format(const kafka::data::rpc::kafka_topic_data&, format_context& ctx) const
-      -> format_context::iterator;
-};
-
-template<>
-struct fmt::formatter<kafka::data::rpc::produce_reply>
-  : formatter<std::string_view> {
-    auto
-    format(const kafka::data::rpc::produce_reply&, format_context& ctx) const
-      -> format_context::iterator;
-};
-
-template<>
-struct fmt::formatter<kafka::data::rpc::kafka_topic_data_result>
-  : formatter<std::string_view> {
-    auto format(
-      const kafka::data::rpc::kafka_topic_data_result&,
-      format_context& ctx) const -> format_context::iterator;
-};
-template<>
-struct fmt::formatter<kafka::data::rpc::topic_partitions>
-  : formatter<std::string_view> {
-    auto
-    format(const kafka::data::rpc::topic_partitions&, format_context& ctx) const
-      -> format_context::iterator;
-};
-
-template<>
-struct fmt::formatter<kafka::data::rpc::get_offsets_request>
-  : formatter<std::string_view> {
-    auto format(
-      const kafka::data::rpc::get_offsets_request&, format_context& ctx) const
-      -> format_context::iterator;
-};
-
-template<>
-struct fmt::formatter<kafka::data::rpc::partition_offsets>
-  : formatter<std::string_view> {
-    auto format(const kafka::data::rpc::partition_offsets&, format_context& ctx)
-      const -> format_context::iterator;
-};
-
-template<>
-struct fmt::formatter<kafka::data::rpc::partition_offset_result>
-  : formatter<std::string_view> {
-    auto format(
-      const kafka::data::rpc::partition_offset_result&,
-      format_context& ctx) const -> format_context::iterator;
-};
-
-template<>
-struct fmt::formatter<kafka::data::rpc::get_offsets_reply>
-  : formatter<std::string_view> {
-    auto format(const kafka::data::rpc::get_offsets_reply&, format_context& ctx)
-      const -> format_context::iterator;
-};

--- a/src/v/kafka/data/rpc/serde.h
+++ b/src/v/kafka/data/rpc/serde.h
@@ -174,4 +174,58 @@ struct get_offsets_reply
 
     fmt::iterator format_to(fmt::iterator it) const;
 };
+
+struct consume_request
+  : serde::
+      envelope<consume_request, serde::version<0>, serde::compat_version<0>> {
+    consume_request() = default;
+    consume_request(
+      model::topic_partition tp,
+      kafka::offset start_offset,
+      kafka::offset max_offset,
+      size_t min_bytes,
+      size_t max_bytes,
+      model::timeout_clock::duration timeout)
+      : tp(std::move(tp))
+      , start_offset(start_offset)
+      , max_offset(max_offset)
+      , min_bytes(min_bytes)
+      , max_bytes(max_bytes)
+      , timeout(timeout) {}
+
+    auto serde_fields() {
+        return std::tie(
+          tp, start_offset, max_offset, min_bytes, max_bytes, timeout);
+    }
+
+    model::topic_partition tp;
+    kafka::offset start_offset;
+    kafka::offset max_offset;
+    size_t min_bytes;
+    size_t max_bytes;
+    model::timeout_clock::duration timeout{};
+
+    fmt::iterator format_to(fmt::iterator it) const;
+};
+
+struct consume_reply
+  : serde::
+      envelope<consume_reply, serde::version<0>, serde::compat_version<0>> {
+    consume_reply() = default;
+    consume_reply(
+      model::topic_partition tp,
+      cluster::errc err,
+      ss::chunked_fifo<model::record_batch> batches)
+      : tp(std::move(tp))
+      , err(err)
+      , batches(std::move(batches)) {}
+
+    auto serde_fields() { return std::tie(tp, err, batches); }
+
+    model::topic_partition tp;
+    cluster::errc err{cluster::errc::success};
+    ss::chunked_fifo<model::record_batch> batches;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+};
 } // namespace kafka::data::rpc

--- a/src/v/kafka/data/rpc/service.cc
+++ b/src/v/kafka/data/rpc/service.cc
@@ -11,7 +11,9 @@
 
 #include "kafka/data/rpc/service.h"
 
+#include "kafka/data/log_reader_config.h"
 #include "kafka/data/partition_proxy.h"
+#include "logger.h"
 #include "model/ktp.h"
 #include "model/metadata.h"
 #include "model/record.h"
@@ -155,6 +157,95 @@ local_service::get_partition_offsets(
       });
 }
 
+ss::future<consume_reply> local_service::consume(consume_request req) {
+    auto ktp = model::ktp(req.tp.topic, req.tp.partition);
+    auto result = co_await consume(
+      ktp,
+      req.start_offset,
+      req.max_offset,
+      req.min_bytes,
+      req.max_bytes,
+      req.timeout);
+
+    if (result.has_error()) {
+        co_return consume_reply(req.tp, result.error(), {});
+    }
+    co_return consume_reply(
+      req.tp, cluster::errc::success, std::move(result.value()));
+}
+
+ss::future<result<ss::chunked_fifo<model::record_batch>, cluster::errc>>
+local_service::consume(
+  const model::ktp& ktp,
+  kafka::offset start_offset,
+  kafka::offset max_offset,
+  size_t min_bytes,
+  size_t max_bytes,
+  model::timeout_clock::duration timeout) {
+    auto shard = _partition_manager->shard_owner(ktp);
+    if (!shard) {
+        co_return cluster::errc::not_leader;
+    }
+
+    auto topic_cfg = _metadata_cache->find_topic_cfg(
+      model::topic_namespace_view(model::kafka_namespace, ktp.get_topic()));
+    if (!topic_cfg) {
+        co_return cluster::errc::topic_not_exists;
+    }
+
+    co_return co_await _partition_manager->consume_from_shard(
+      *shard,
+      ktp,
+      [start_offset, max_offset, min_bytes, max_bytes, timeout](
+        this auto, kafka::partition_proxy* partition)
+        -> ss::future<
+          result<ss::chunked_fifo<model::record_batch>, cluster::errc>> {
+          if (!partition->is_leader()) {
+              co_return cluster::errc::not_leader;
+          }
+
+          // Create log reader config
+          kafka::log_reader_config reader_cfg(
+            start_offset,
+            max_offset,
+            min_bytes,
+            max_bytes,
+            std::nullopt, // first_timestamp
+            std::nullopt, // abort_source
+            std::nullopt, // client_address
+            false);       // strict_max_bytes
+
+          // Create reader
+          auto translating_reader = co_await partition->make_reader(
+            reader_cfg, model::timeout_clock::now() + timeout);
+
+          // Consume batches from reader
+          try {
+              auto data = co_await model::consume_reader_to_memory(
+                std::move(translating_reader.reader),
+                model::timeout_clock::now() + timeout);
+
+              // Convert from chunked_circular_buffer to chunked_fifo
+              ss::chunked_fifo<model::record_batch> batches;
+              batches.reserve(data.size());
+              for (auto& batch : data) {
+                  batches.push_back(std::move(batch));
+              }
+
+              co_return batches;
+          } catch (const ss::timed_out_error&) {
+              co_return cluster::errc::timeout;
+          } catch (...) {
+              vlog(
+                log.warn,
+                "Error consuming from partition {}: {}",
+                partition->ntp(),
+                std::current_exception());
+              co_return cluster::errc::partition_operation_failed;
+          }
+      });
+}
+
 ss::future<kafka_topic_data_result> local_service::produce(
   kafka_topic_data data, model::timeout_clock::duration timeout) {
     auto ktp = model::ktp(data.tp.topic, data.tp.partition);
@@ -235,6 +326,12 @@ ss::future<get_offsets_reply> network_service::get_offsets(
     auto results = co_await _service->local().get_offsets(
       std::move(req.topics));
     co_return get_offsets_reply(std::move(results));
+}
+
+ss::future<consume_reply>
+network_service::consume(consume_request req, ::rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
+    co_return co_await _service->local().consume(std::move(req));
 }
 
 } // namespace kafka::data::rpc

--- a/src/v/kafka/data/rpc/service.h
+++ b/src/v/kafka/data/rpc/service.h
@@ -40,6 +40,8 @@ public:
     ss::future<partition_offsets_map>
     get_offsets(chunked_vector<topic_partitions> topics);
 
+    ss::future<consume_reply> consume(consume_request req);
+
 private:
     ss::future<kafka_topic_data_result>
       produce(kafka_topic_data, model::timeout_clock::duration);
@@ -51,6 +53,15 @@ private:
 
     ss::future<result<partition_offsets, cluster::errc>>
       get_partition_offsets(model::topic, model::partition_id);
+
+    ss::future<result<ss::chunked_fifo<model::record_batch>, cluster::errc>>
+    consume(
+      const model::ktp& ktp,
+      kafka::offset start_offset,
+      kafka::offset max_offset,
+      size_t min_bytes,
+      size_t max_bytes,
+      model::timeout_clock::duration timeout);
 
     std::unique_ptr<kafka::data::rpc::topic_metadata_cache> _metadata_cache;
     std::unique_ptr<kafka::data::rpc::partition_manager> _partition_manager;
@@ -75,6 +86,9 @@ public:
 
     ss::future<get_offsets_reply>
     get_offsets(get_offsets_request, ::rpc::streaming_context&) override;
+
+    ss::future<consume_reply>
+    consume(consume_request, ::rpc::streaming_context&) override;
 
 private:
     ss::sharded<local_service>* _service;

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -500,6 +500,17 @@ public:
         return _fake_proxy->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
     }
 
+    ss::future<result<ss::chunked_fifo<model::record_batch>, cluster::errc>>
+    consume_from_shard(
+      ss::shard_id shard_id,
+      const model::ktp& ktp,
+      ss::noncopyable_function<ss::future<
+        result<ss::chunked_fifo<model::record_batch>, cluster::errc>>(
+        kafka::partition_proxy*)> fn,
+      require_leader) final {
+        return _fake_proxy->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
+    }
+
     bool is_current_shard_leader(const model::ntp& ntp) const override {
         return _fake_proxy->is_current_shard_leader(ntp);
     }

--- a/src/v/kafka/data/rpc/test/kafka_data_rpc_test.cc
+++ b/src/v/kafka/data/rpc/test/kafka_data_rpc_test.cc
@@ -154,6 +154,19 @@ public:
           .get();
     }
 
+    result<consume_reply, cluster::errc> consume(
+      model::topic_partition tp,
+      kafka::offset start_offset,
+      kafka::offset max_offset,
+      size_t min_bytes = 0,
+      size_t max_bytes = std::numeric_limits<size_t>::max()) {
+        return _kd->client()
+          .local()
+          .consume(
+            tp, start_offset, max_offset, min_bytes, max_bytes, 1s)
+          .get();
+    }
+
 private:
     record_batches batches_for(model::node_id node, const model::ntp& ntp) {
         auto manager = node == self_node ? _kd->local_partition_manager()
@@ -249,6 +262,58 @@ TEST_P(KafkaDataRpcTest, ClientCanRequestPartitionOffsets) {
     auto p_offsets_2
       = offsets_2[not_existing.tp.topic][not_existing.tp.partition];
     EXPECT_EQ(p_offsets_2.err, cluster::errc::topic_not_exists);
+}
+
+TEST_P(KafkaDataRpcTest, ClientCanConsume) {
+    auto ntp = make_ntp("foo");
+    create_topic(model::topic_namespace(ntp.ns, ntp.tp.topic));
+
+    // Produce some batches
+    auto batches = record_batches::make();
+    cluster::errc ec = produce(ntp, batches);
+    EXPECT_EQ(ec, cluster::errc::success)
+      << cluster::error_category().message(int(ec));
+
+    // Verify batches were produced to the leader
+    EXPECT_EQ(leader_batches(ntp), batches);
+
+    // Consume from offset 0 to max
+    auto consume_result = consume(
+      ntp.tp,
+      kafka::offset(0),
+      kafka::offset::max(),
+      0,
+      std::numeric_limits<size_t>::max());
+
+    ASSERT_TRUE(consume_result.has_value());
+    auto reply = std::move(consume_result.value());
+
+    EXPECT_EQ(reply.err, cluster::errc::success)
+      << cluster::error_category().message(int(reply.err));
+    EXPECT_EQ(reply.tp, ntp.tp);
+    EXPECT_EQ(reply.batches.size(), batches.size());
+
+    // Verify consumed batches match produced batches
+    auto batches_it = batches.underlying.begin();
+    for (const auto& consumed_batch : reply.batches) {
+        EXPECT_EQ(
+          consumed_batch.header().record_count,
+          batches_it->header().record_count);
+        ++batches_it;
+    }
+
+    // Test consuming non-existent topic
+    auto not_existing = make_ntp("bar");
+    auto ne_result = consume(
+      not_existing.tp,
+      kafka::offset(0),
+      kafka::offset::max(),
+      0,
+      std::numeric_limits<size_t>::max());
+
+    ASSERT_TRUE(ne_result.has_value());
+    auto ne_reply = std::move(ne_result.value());
+    EXPECT_EQ(ne_reply.err, cluster::errc::not_leader);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
## Summary

This PR implements a new consume RPC method for the kafka data RPC service that enables efficient reading of batches from partitions.

## Changes

- **RPC Definition**: Added `consume` method to rpc.json with `consume_request` and `consume_reply` types
- **Data Structures**: Implemented request/reply types with topic_partition, offsets, byte limits, and timeout
- **Service Layer**: 
  - `local_service::consume()` creates a reader using `partition_proxy::make_reader()`
  - Reads batches using `model::consume_reader_to_memory()`
  - Handles timeouts and errors appropriately
- **Client Layer**: 
  - Finds partition leader using metadata cache
  - Routes to local service if leader is local
  - Makes RPC call to remote node if leader is remote
  - Always returns replies with errors embedded (never outer errors)
- **Infrastructure**: Added `consume_from_shard()` method to partition_manager interface
- **Code Quality**: Migrated all serde types from fmt::formatter to format_to() pattern
- **Tests**: Added comprehensive unit tests covering both local and remote leader scenarios

## Design Decisions

- **Single partition per request**: Each consume request handles one partition for simplicity
- **format_to() pattern**: All types use format_to() member functions instead of fmt::formatter specializations
- **Error handling**: All errors are embedded in replies for consistency with other operations like get_partition_offsets
- **Reader-based consumption**: Uses partition_proxy's make_reader() for efficient batch reading

## Test Results

All tests passing (8/8):
- 2 × ClientCanProduce (local/remote)
- 2 × ClientCanUpdateTopics (local/remote)
- 2 × ClientCanRequestPartitionOffsets (local/remote)
- **2 × ClientCanConsume (local/remote)** ✨ **(NEW)**

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)